### PR TITLE
Fix missing i18n updates for repeated keys

### DIFF
--- a/index.html
+++ b/index.html
@@ -311,40 +311,18 @@
 
   <script>
     // --- i18n core ---
-    const I18N_KEYS = [
-      "meta.title","meta.description","a11y.skip",
-      "nav.role","nav.services","nav.about","nav.book",
-      "hero.tagline","hero.title","hero.subtitle","hero.body",
-      "cta.book","cta.whatsapp","cta.call","cta.email",
-      "contacts.email_text","contacts.phone_text","contacts.whatsapp_text",
-      "social.facebook","social.instagram","social.linkedin",
-      "metrics.transactions_label","metrics.transactions_value",
-      "metrics.response_label","metrics.response_value",
-      "metrics.focus_label","metrics.focus_value",
-      "services.title","services.lead",
-      "services.card1.title","services.card1.body",
-      "services.card2.title","services.card2.body",
-      "services.card3.title","services.card3.body",
-      "about.title","about.body","about.bullets.0","about.bullets.1","about.bullets.2",
-      "about.cert_label","about.cert_value","about.cert_note","about.tags.0","about.tags.1",
-      "listing.title","listing.cta","listing.bullets.0","listing.bullets.1","listing.bullets.2",
-      "cta.title","cta.subtitle",
-      "footer.privacy","footer.terms","footer.legal"
-    ];
-
     const langSelect = document.getElementById("languageSwitcher");
     const saved = localStorage.getItem("siteLang") || "pt";
     langSelect.value = saved;
 
     function applyI18n(dict){
-      I18N_KEYS.forEach(k=>{
-        const el = document.querySelector(`[data-i18n="${k}"]`);
-        if(el && dict && dict[k] !== undefined){
-          if(el.tagName === "META"){
-            el.setAttribute("content", dict[k]);
-          } else {
-            el.textContent = dict[k];
-          }
+      document.querySelectorAll('[data-i18n]').forEach(el=>{
+        const key = el.getAttribute('data-i18n');
+        if(!dict || dict[key] === undefined) return;
+        if(el.tagName === "META"){
+          el.setAttribute("content", dict[key]);
+        } else {
+          el.textContent = dict[key];
         }
       });
       // update <html lang="">


### PR DESCRIPTION
## Summary
- ensure translation script updates all elements sharing the same `data-i18n` key by iterating over all matches instead of only the first
- remove hardcoded key list and scan `data-i18n` elements directly for easier maintenance

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689a160b86548331940502ce7d7fb63f